### PR TITLE
passing config to proxit.js when brought in via a grunt task

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -1,5 +1,5 @@
-module.exports = function(options) {
-    options = require('../util/config')(options);
+module.exports = function(config) {
+    options = require('../util/config')(config);
 
     var express = require('express'),
         app = express(),
@@ -7,7 +7,7 @@ module.exports = function(options) {
         port = options.port || 9000;
 
     app
-        .use(require('../proxit')())
+        .use(require('../proxit')(config))
         .listen(port, function() {
             log.green('Server started on port', port, (options.verbose) ? ' (verbose logging enabled)' : '', '...');
         });


### PR DESCRIPTION
The config wasn't being passed to proxit.js so when proxit.js went to build the config it wasn't using the command line options and thus defaulted to looking for proxit.json.
