### PR TITLE
Exporting 'local' to be used in node-cmp

### DIFF
--- a/lib/proxit.js
+++ b/lib/proxit.js
@@ -1,5 +1,6 @@
 var config = require('./config'),
     hosts = require('./hosts'),
+    local = require('./middleware/local'),
     proxy = require('./middleware/proxy'),
     logger = require('./util/logger'),
     resolver = require('./resolver'),
@@ -32,6 +33,7 @@ var proxit = module.exports = function(options) {
 proxit.api = {
     hosts: hosts,
     logger: logger,
+    local: local,
     proxy: proxy,
     server: require('./server/server'),
     resolver: resolver,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "proxit",
     "description": "Simple proxy server built on express / connect.",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "bin": "server.js",
     "main": "lib/proxit",
     "engines": {


### PR DESCRIPTION
This simple change export `local` in `proxit.api` so that it can be used in `cmp-plugin-proxit` to serve static files.
